### PR TITLE
Fix undeclared PATH_MAX on Mac

### DIFF
--- a/files/files.c
+++ b/files/files.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <dirent.h>
+#include <limits.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/tests/runTests.sh
+++ b/tests/runTests.sh
@@ -3,7 +3,7 @@ function runTests {
   for file in "${@:2}"; do
     echo ${file}
     touch "${file}.out"
-    "$1" ${file} 2>&1 | diff --color "${file}.out" -
+    "$1" ${file} 2>&1 | diff "${file}.out" -
   done
 }
 
@@ -11,7 +11,7 @@ function commit {
   for file in "${@:2}"; do
     echo "${file}.out"
     touch "${file}.out"
-    "$1" ${file} 2>&1 | diff --color "${file}.out" -
+    "$1" ${file} 2>&1 | diff "${file}.out" -
     "$1" ${file} &> "${file}.out"
   done
 }


### PR DESCRIPTION
I was getting `error: use of undeclared identifier 'PATH_MAX'` on both gcc and clang. This seems to fix it.

Thanks for posting this!  I'm looking forward to trying it out.