### PR TITLE
Make map work with set (and others)

### DIFF
--- a/prelude/list.ptls
+++ b/prelude/list.ptls
@@ -211,9 +211,10 @@ hasPrefix(prefix, list) =
 -------------------------------------------------------------------------------
 -- Apply a function to each list element, make a list of the results
 
-map(func, list) =
+map(func, iterable) =
   if isEmpty(list) then []
   else [func(head(list))] ++ map(func, tail(list))
+  where list = toList(iterable)
 
 -------------------------------------------------------------------------------
 -- Apply a test to each list element, make new list of passing elements


### PR DESCRIPTION
This is my attempt to solve #11.
I added a call to `toList` to the map function that is being called by the `for` comprehension.  That allows `for` to be used with a lot of things, such as lists, sets, tuples and even strings.

This does solve the issue that `for` needs to work with sets, but it might be *too much*. Maybe iterating over strings isn't intended?